### PR TITLE
Utiliser un dictionnaire local pour autocorriger chaque mot

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Prototype d'autocorrecteur global pour Windows.
 1. Installer les dépendances :
 
    ```bash
-   pip install keyboard language_tool_python
+   pip install keyboard pyspellchecker
    ```
 
 2. Exécuter le script `autocorrect.py`.
 
-3. Tapez du texte dans n'importe quelle application : à chaque espace ou ponctuation, le mot précédent est analysé et corrigé automatiquement.
+3. Tapez du texte dans n'importe quelle application : à chaque appui sur la barre d'espace, le mot précédent est comparé à un dictionnaire local et éventuellement remplacé par la meilleure suggestion.
 
-Le script repose sur [LanguageTool](https://languagetool.org/) pour la correction en français et utilise la bibliothèque `keyboard` pour intercepter les frappes.
+Le script utilise la bibliothèque `keyboard` pour intercepter les frappes et [`pyspellchecker`](https://github.com/barrust/pyspellchecker) pour la recherche de la correction la plus probable sans appel à un service externe.

--- a/autocorrect.py
+++ b/autocorrect.py
@@ -1,42 +1,54 @@
 import threading
 
 import keyboard
-import language_tool_python
+from spellchecker import SpellChecker
 
 
 class AutoCorrector:
     """Listen to keyboard events and autocorrect words on the fly."""
 
     def __init__(self) -> None:
-        self.tool = language_tool_python.LanguageTool('fr')
+        self.spell = SpellChecker(language="fr")
         self.buffer = []
         self.sending = False
+        self.just_corrected = False
+        self.skip_once = False
         keyboard.hook(self._handle_event)
 
     def _handle_event(self, event) -> None:
-        if self.sending or event.event_type != 'down':
+        if self.sending or event.event_type != "down":
             return
         key = event.name
-        if key == 'space' or key in {'.', ',', ';', '?', '!', 'enter'}:
-            self.buffer.append(' ')
+        if key == "space":
+            if self.skip_once:
+                self.skip_once = False
+                self.buffer = []
+                return
             self._apply_correction()
             self.buffer = []
-        elif key == 'backspace':
-            if self.buffer:
+        elif key == "backspace":
+            if self.just_corrected:
+                self.skip_once = True
+                self.just_corrected = False
+            elif self.buffer:
                 self.buffer.pop()
         elif len(key) == 1:
             self.buffer.append(key)
 
     def _apply_correction(self) -> None:
-        text = ''.join(self.buffer)
-        matches = self.tool.check(text)
-        corrected = language_tool_python.utils.correct(text, matches)
-        if corrected != text:
+        word = "".join(self.buffer)
+        if not word:
+            return
+        corrected = self.spell.correction(word)
+        if corrected and corrected != word:
             self.sending = True
-            for _ in text:
-                keyboard.send('backspace')
-            keyboard.write(corrected)
+            for _ in range(len(word) + 1):  # remove word and trailing space
+                keyboard.send("backspace")
+            keyboard.write(corrected + " ")
             self.sending = False
+            self.just_corrected = True
+        else:
+            self.just_corrected = False
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Résumé
- Remplacement de LanguageTool par `pyspellchecker` afin d'assurer une correction locale.
- Correction appliquée à chaque appui sur espace avec interception du clavier.
- Évite de corriger un mot que l'utilisateur modifie immédiatement après.

## Tests
- `python -m py_compile autocorrect.py`


------
https://chatgpt.com/codex/tasks/task_e_6894ca032634832c9d0414e1b0947ef4